### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Christopher Baker <info@christopherbaker.net>
 maintainer=Christopher Baker <info@christopherbaker.net>
 sentence=An Arduino library for calculating a CRC32 checksum.
 paragraph=An Arduino library for calculating a CRC32 checksum.
+category=Data Processing
 url=https://github.com/bakercp/CRC32
 architectures=avr


### PR DESCRIPTION
Fixes the `WARNING: Category '' in library CRC32 is not valid. Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6. If you disagree with my category choice I'm happy to change the category to any of the other [valid category values](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification) and squash to a single commit.
